### PR TITLE
Use "process.stdout.write" not to include newline

### DIFF
--- a/bin/selector2regexp
+++ b/bin/selector2regexp
@@ -2,4 +2,5 @@
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-require('../dist/cli').default();
+const cliResult = require('../dist/cli').default();
+cliResult && process.stdout.write(cliResult + '\n');

--- a/bin/selector2regexp
+++ b/bin/selector2regexp
@@ -2,5 +2,4 @@
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-const cliResult = require('../dist/cli').default();
-cliResult && process.stdout.write(cliResult + '\n');
+require('../dist/cli').default();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,5 +22,5 @@ Usage:
     throw new Error('Multiple input is not supported.');
   }
 
-  console.log(selector2Regexp(input[0]));
+  process.stdout.write(selector2Regexp(input[0]));
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,5 +23,5 @@ Usage:
     throw new Error('Multiple input is not supported.');
   }
 
-  process.stdout.write(selector2Regexp(input[0]) + '\n');
+  return selector2Regexp(input[0]);
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import selector2Regexp from './index';
 import yargs from 'yargs';
 
-export default () => {
+export default (args: string[]) => {
   const argv = yargs
     .usage(
       `
@@ -14,7 +14,8 @@ Usage:
     .help('h')
     .alias('h', 'help')
     .version(require('../package.json').version)
-    .alias('v', 'version').argv;
+    .alias('v', 'version')
+    .parse(args);
 
   const input = argv._;
 
@@ -22,5 +23,5 @@ Usage:
     throw new Error('Multiple input is not supported.');
   }
 
-  process.stdout.write(selector2Regexp(input[0]));
+  process.stdout.write(selector2Regexp(input[0]) + '\n');
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,5 +23,5 @@ Usage:
     throw new Error('Multiple input is not supported.');
   }
 
-  return selector2Regexp(input[0]);
+  process.stdout.write(selector2Regexp(input[0]) + '\n');
 };

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,3 +1,20 @@
-import cli from '../src/cli';
+import path from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
 
-describe('CLI', () => {});
+const cliMock = async (args: string[]) => {
+  const asyncExec = promisify(exec);
+  const { stdout, stderr } = await asyncExec(`${path.resolve('bin/selector2regexp')} ${args.join(' ')}`);
+
+  if (stderr) {
+    return stderr;
+  }
+
+  return stdout;
+};
+
+describe('CLI', () => {
+  it('.button', async () => {
+    await expect(cliMock(['.button'])).resolves.toBe('class=[\'"]\\w*\\s*(?<!\\w)(button)(?!\\w)\\s*\\w*[\'"]' + '\n');
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,6 @@
+import { spawn } from 'child_process';
+const s2r = spawn('s2r', ['.button']);
+
+s2r.stdout.on('data', (data) => {
+  console.log(`stdout: ${data}`);
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,6 +1,3 @@
-import { spawn } from 'child_process';
-const s2r = spawn('s2r', ['.button']);
+import cli from '../src/cli';
 
-s2r.stdout.on('data', (data) => {
-  console.log(`stdout: ${data}`);
-});
+describe('CLI', () => {});


### PR DESCRIPTION
s2r's results include `\n` now.
It's a bother when we save to clipboard for using search keywords.

So, I changed not to include newline.