### PR TITLE
Enable to match tags with attribute when Type selector

### DIFF
--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -44,7 +44,7 @@ const attributeRegexp = <T extends string>(attribute: string, value: T | T[] | n
 };
 
 const openingTagRegexp = (type: string, attribute?: string) => {
-  return START_OF_BRACKET + type + END_OF_BRACKET;
+  return START_OF_BRACKET + `(${type})` + '\\s*.*?' + END_OF_BRACKET;
 };
 
 const closingTagRegexp = (type: string) => {

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -54,6 +54,8 @@ describe('generateRegexString()', () => {
 
     it('To match generated regexp in HTML', () => {
       expect(new RegExp(transformToRegexp(selector('div'))).test(`<div id="app"></div>`)).toBeTruthy();
+      expect(new RegExp(transformToRegexp(selector('div'))).test(`<div id="app" class="sample"></div>`)).toBeTruthy();
+      expect(new RegExp(transformToRegexp(selector('a'))).test(`<div id="app" class="sample"><a href=""></a></div>`)).toBeTruthy();
     });
   });
 

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -49,7 +49,11 @@ describe('generateRegexString()', () => {
 
   describe('Type selector', () => {
     it('Should be equal', () => {
-      expect(transformToRegexp(selector('div'))).toBe('<\\s*div\\s*>');
+      expect(transformToRegexp(selector('div'))).toBe('<\\s*(div)\\s*.*?\\s*>');
+    });
+
+    it('To match generated regexp in HTML', () => {
+      expect(new RegExp(transformToRegexp(selector('div'))).test(`<div id="app"></div>`)).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
Example

```
s2r 'div'
must be match:
`<div class="button"></div>`

s2r 'a'
must be match:
`<div class="button"><a href="/"?></a></div>`

```