### PR TITLE
Support multiple selector for className and Type selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Transform CSS Selector to a Regexp string for searching matched elements in HTML
 **NOTE：This tool is an experiment.**
 
 - Generated regexps **only work JavaScript based environments**. ex. VSCode, Node.js, Chrome..
-- Generated regexps contains ES2018's features. "Lookbehind assertion" and "Negative lookbehind assertion".<br>
+- Generated regexps contain ES2018's features. "Lookbehind assertion" and "Negative lookbehind assertion".<br>
   Please check their statements:<br>https://caniuse.com/#feat=mdn-javascript_builtins_regexp_lookbehind_assertion,
 
 ![](https://github.com/m-yoshiro/Selector2Regexp/workflows/TEST/badge.svg)
@@ -25,6 +25,37 @@ s2r '.button'
 # Save to clipboard
 s2r '.button' | pbcopy
 ```
+
+### Supported selector patterns
+
+- **Single selector**
+
+  ```sh
+  # Type Selector
+  s2r 'div'
+
+  # Classs Selector
+  s2r '.single'
+
+  # Id Selector
+  s2r '#app'
+
+  # Attribute Selector // Supported matcher is just "=" only now.
+  s2r '[data-state=active]'
+  ```
+
+- **Descendant selector**
+
+  ```sh
+  s2r '.parent .child'
+  ```
+
+- **Multiples**
+
+  ```sh
+  s2r '.button.button--primary'
+  s2r 'div.panel.flex'
+  ```
 
 <!--
 ```

--- a/src/lib/transformToRegexp.ts
+++ b/src/lib/transformToRegexp.ts
@@ -1,6 +1,5 @@
 import csstree from 'css-tree';
 import { visitor } from './visitor';
-import { s2rNode } from '../../types';
 
 type targetNode = csstree.ClassSelector | csstree.IdSelector | csstree.TypeSelector | csstree.AttributeSelector | csstree.WhiteSpace | csstree.Combinator | csstree.PseudoElementSelector | csstree.SelectorList;
 
@@ -9,8 +8,20 @@ export default function (selector: csstree.Selector) {
     throw new Error(`Bad node type ${selector.type} for 'generateRegexString'.`);
   }
 
-  const result: s2rNode<targetNode>[] = [];
-  const prev = (result: s2rNode<targetNode>[]) => (result.length > 0 ? result[result.length - 1] : null);
+  let list: targetNode[] = [];
+
+  const createS2rList = (list: targetNode[]) => {
+    return list.map((node, i, o) => {
+      const next = o[i + 1];
+      const prev = o[i - 1];
+
+      return {
+        data: node,
+        next: next ? next : null,
+        prev: prev ? prev : null,
+      };
+    });
+  };
 
   csstree.walk(selector, (node) => {
     switch (node.type) {
@@ -22,16 +33,14 @@ export default function (selector: csstree.Selector) {
       case 'Combinator':
       case 'PseudoElementSelector':
       case 'SelectorList':
-        result.push({
-          type: node.type,
-          data: node,
-          prev: prev(result),
-        });
+        list.push(node);
         break;
       default:
         break;
     }
   });
 
-  return result.map((node) => visitor[node.data.type](node)).join('');
+  return createS2rList(list)
+    .map((node) => visitor[node.data.type](node))
+    .join('');
 }

--- a/src/lib/transformToRegexp.ts
+++ b/src/lib/transformToRegexp.ts
@@ -1,47 +1,36 @@
 import csstree from 'css-tree';
 import { visitor } from './visitor';
+import { s2rNode } from '../../types';
+
+type targetNode = csstree.ClassSelector | csstree.IdSelector | csstree.TypeSelector | csstree.AttributeSelector | csstree.WhiteSpace | csstree.Combinator | csstree.PseudoElementSelector | csstree.SelectorList;
 
 export default function (selector: csstree.Selector) {
   if (selector.type !== 'Selector') {
     throw new Error(`Bad node type ${selector.type} for 'generateRegexString'.`);
   }
 
-  const result: unknown[] = [];
-  csstree.walk(selector, (node) => {
-    // TODO: To be simple
-    // if (node.type in visitor) {
-    //   visitor[node.type](node);
-    // }
+  const result: s2rNode<targetNode, targetNode>[] = [];
 
+  csstree.walk(selector, (node) => {
     switch (node.type) {
       case 'ClassSelector':
-        result.push(visitor[node.type](node));
-        break;
       case 'IdSelector':
-        result.push(visitor[node.type](node));
-        break;
       case 'TypeSelector':
-        result.push(visitor[node.type](node));
-        break;
       case 'WhiteSpace':
-        result.push(visitor[node.type](node));
-        break;
       case 'AttributeSelector':
-        result.push(visitor[node.type](node));
-        break;
       case 'Combinator':
-        result.push(visitor[node.type](node));
-        break;
       case 'PseudoElementSelector':
-        result.push(visitor[node.type](node));
-        break;
       case 'SelectorList':
-        result.push(visitor[node.type](node));
+        result.push({
+          type: node.type,
+          data: node,
+          prev: null,
+        });
         break;
       default:
         break;
     }
   });
 
-  return result.join('');
+  return result.map((node) => visitor[node.data.type](node)).join('');
 }

--- a/src/lib/transformToRegexp.ts
+++ b/src/lib/transformToRegexp.ts
@@ -1,7 +1,6 @@
 import csstree from 'css-tree';
 import { visitor } from './visitor';
-
-type targetNode = csstree.ClassSelector | csstree.IdSelector | csstree.TypeSelector | csstree.AttributeSelector | csstree.WhiteSpace | csstree.Combinator | csstree.PseudoElementSelector | csstree.SelectorList;
+import { targetNode } from '../../types';
 
 export default function (selector: csstree.Selector) {
   if (selector.type !== 'Selector') {
@@ -11,14 +10,12 @@ export default function (selector: csstree.Selector) {
   let list: targetNode[] = [];
 
   const createS2rList = (list: targetNode[]) => {
+    // [1, 3, 4, 5, 6]
     return list.map((node, i, o) => {
-      const next = o[i + 1];
-      const prev = o[i - 1];
-
       return {
         data: node,
-        next: next ? next : null,
-        prev: prev ? prev : null,
+        next: () => (o[i + 1] ? o[i + 1] : null),
+        prev: () => (o[i - 1] ? o[i - 1] : null),
       };
     });
   };
@@ -41,6 +38,6 @@ export default function (selector: csstree.Selector) {
   });
 
   return createS2rList(list)
-    .map((node) => visitor[node.data.type](node))
+    .map((node) => visitor[node.data.type](node, list))
     .join('');
 }

--- a/src/lib/transformToRegexp.ts
+++ b/src/lib/transformToRegexp.ts
@@ -9,7 +9,8 @@ export default function (selector: csstree.Selector) {
     throw new Error(`Bad node type ${selector.type} for 'generateRegexString'.`);
   }
 
-  const result: s2rNode<targetNode, targetNode>[] = [];
+  const result: s2rNode<targetNode>[] = [];
+  const prev = (result: s2rNode<targetNode>[]) => (result.length > 0 ? result[result.length - 1] : null);
 
   csstree.walk(selector, (node) => {
     switch (node.type) {
@@ -24,7 +25,7 @@ export default function (selector: csstree.Selector) {
         result.push({
           type: node.type,
           data: node,
-          prev: null,
+          prev: prev(result),
         });
         break;
       default:

--- a/src/lib/transformToRegexp.ts
+++ b/src/lib/transformToRegexp.ts
@@ -1,6 +1,6 @@
 import csstree from 'css-tree';
 import { visitor } from './visitor';
-import { targetNode } from '../../types';
+import { s2rNode, targetNode } from '../../types';
 
 export default function (selector: csstree.Selector) {
   if (selector.type !== 'Selector') {
@@ -10,14 +10,17 @@ export default function (selector: csstree.Selector) {
   let list: targetNode[] = [];
 
   const createS2rList = (list: targetNode[]) => {
-    // [1, 3, 4, 5, 6]
-    return list.map((node, i, o) => {
-      return {
+    const result: s2rNode<targetNode>[] = [];
+
+    list.forEach((node, i) => {
+      result.push({
         data: node,
-        next: () => (o[i + 1] ? o[i + 1] : null),
-        prev: () => (o[i - 1] ? o[i - 1] : null),
-      };
+        next: () => (result[i + 1] ? result[i + 1] : null),
+        prev: () => (result[i - 1] ? result[i - 1] : null),
+      });
     });
+
+    return result;
   };
 
   csstree.walk(selector, (node) => {

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -1,5 +1,5 @@
 import csstree, { PseudoElementSelector } from 'css-tree';
-import { s2rNode } from '../../types';
+import { s2rNode, targetNode } from '../../types';
 
 const START_OF_BRACKET = '<\\s*';
 const END_OF_BRACKET = '\\s*>';
@@ -19,14 +19,14 @@ type SelectorRegexpString = string;
 type NoSupport = Error | void;
 
 export type Visitor = {
-  ClassSelector: (node: s2rNode<csstree.CssNode>) => SelectorRegexpString;
-  IdSelector: (node: s2rNode<csstree.CssNode>) => SelectorRegexpString;
-  AttributeSelector: (node: s2rNode<csstree.CssNode>) => SelectorRegexpString;
-  WhiteSpace: (node: s2rNode<csstree.CssNode>) => SelectorRegexpString;
-  TypeSelector: (node: s2rNode<csstree.CssNode>) => SelectorRegexpString;
-  Combinator: (node: s2rNode<csstree.CssNode>) => NoSupport;
-  PseudoElementSelector: (node: s2rNode<csstree.CssNode>) => NoSupport;
-  SelectorList: (node: s2rNode<csstree.CssNode>) => NoSupport;
+  ClassSelector: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  IdSelector: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  AttributeSelector: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  WhiteSpace: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  TypeSelector: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  Combinator: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => NoSupport;
+  PseudoElementSelector: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => NoSupport;
+  SelectorList: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => NoSupport;
 };
 
 const attributeRegexp = <T extends string>(attribute: string, value: T | T[] | null) => {
@@ -53,7 +53,7 @@ const closingTagRegexp = (type: string) => {
 };
 
 export const visitor: Visitor = {
-  ClassSelector(node) {
+  ClassSelector(node, list) {
     if (node.data.type === 'ClassSelector') {
       // if (node.prev && node.prev.data.type === 'ClassSelector') {
       // }

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -19,14 +19,14 @@ type SelectorRegexpString = string;
 type NoSupport = Error | void;
 
 export type Visitor = {
-  ClassSelector: (node: s2rNode<csstree.CssNode, csstree.CssNode>) => SelectorRegexpString;
-  IdSelector: (node: s2rNode<csstree.CssNode, csstree.CssNode>) => SelectorRegexpString;
-  AttributeSelector: (node: s2rNode<csstree.CssNode, csstree.CssNode>) => SelectorRegexpString;
-  WhiteSpace: (node: s2rNode<csstree.CssNode, csstree.CssNode>) => SelectorRegexpString;
-  TypeSelector: (node: s2rNode<csstree.CssNode, csstree.CssNode>) => SelectorRegexpString;
-  Combinator: (node: s2rNode<csstree.CssNode, csstree.CssNode>) => NoSupport;
-  PseudoElementSelector: (node: s2rNode<csstree.CssNode, csstree.CssNode>) => NoSupport;
-  SelectorList: (node: s2rNode<csstree.CssNode, csstree.CssNode>) => NoSupport;
+  ClassSelector: (node: s2rNode<csstree.CssNode>) => SelectorRegexpString;
+  IdSelector: (node: s2rNode<csstree.CssNode>) => SelectorRegexpString;
+  AttributeSelector: (node: s2rNode<csstree.CssNode>) => SelectorRegexpString;
+  WhiteSpace: (node: s2rNode<csstree.CssNode>) => SelectorRegexpString;
+  TypeSelector: (node: s2rNode<csstree.CssNode>) => SelectorRegexpString;
+  Combinator: (node: s2rNode<csstree.CssNode>) => NoSupport;
+  PseudoElementSelector: (node: s2rNode<csstree.CssNode>) => NoSupport;
+  SelectorList: (node: s2rNode<csstree.CssNode>) => NoSupport;
 };
 
 const attributeRegexp = <T extends string>(attribute: string, value: T | T[] | null) => {

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -55,6 +55,9 @@ const closingTagRegexp = (type: string) => {
 export const visitor: Visitor = {
   ClassSelector(node) {
     if (node.data.type === 'ClassSelector') {
+      // if (node.prev && node.prev.data.type === 'ClassSelector') {
+      // }
+
       return attributeRegexp(CLASS_ATTRIBUTE, node.data.name);
     }
 

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -92,49 +92,49 @@ const findAfter = (node: s2rNode<csstree.CssNode>, type: targetNode['type']) => 
 
 export const visitor: Visitor = {
   ClassSelector(node, list) {
-    if (node.data.type === 'ClassSelector') {
-      if (findBefore(node, 'ClassSelector').length > 0) {
-        return '';
-      }
-
-      const afters = findAfter(node, 'ClassSelector');
-
-      if (afters.length > 0) {
-        return attributeRegexp(CLASS_ATTRIBUTE, [node.data.name, ...afters.map((node) => node.data.name)]);
-      }
-
-      return attributeRegexp(CLASS_ATTRIBUTE, node.data.name);
+    if (node.data.type !== 'ClassSelector') {
+      return '';
     }
 
-    return '';
+    if (findBefore(node, 'ClassSelector').length > 0) {
+      return '';
+    }
+
+    const afters = findAfter(node, 'ClassSelector');
+
+    if (afters.length > 0) {
+      return attributeRegexp(CLASS_ATTRIBUTE, [node.data.name, ...afters.map((node) => node.data.name)]);
+    }
+
+    return attributeRegexp(CLASS_ATTRIBUTE, node.data.name);
   },
 
   IdSelector(node) {
-    if (node.data.type === 'IdSelector') {
-      return attributeRegexp(ID_ATTRIBUTE, node.data.name);
+    if (node.data.type !== 'IdSelector') {
+      return '';
     }
-    return '';
+    return attributeRegexp(ID_ATTRIBUTE, node.data.name);
   },
 
   AttributeSelector(node) {
-    if (node.data.type === 'AttributeSelector') {
-      return attributeRegexp(node.data.name.name, (node.data.value as csstree.Identifier).name);
+    if (node.data.type !== 'AttributeSelector') {
+      return '';
     }
-    return '';
+    return attributeRegexp(node.data.name.name, (node.data.value as csstree.Identifier).name);
   },
 
   TypeSelector(node) {
-    if (node.data.type === 'TypeSelector') {
-      return openingTagRegexp(node.data.name);
+    if (node.data.type !== 'TypeSelector') {
+      return '';
     }
-    return '';
+    return openingTagRegexp(node.data.name);
   },
 
   WhiteSpace(node) {
-    if (node.data.type === 'WhiteSpace') {
-      return END_OF_BRACKET + SPACE_BETWEEN_ELEMENT + `(?:\\s${ANY_OPENING_TAG}.*\\s*)*?` + START_OF_BRACKET + TYPE_NAME + ATTRIBUTE_SEPARATOR;
+    if (node.data.type !== 'WhiteSpace') {
+      return '';
     }
-    return '';
+    return END_OF_BRACKET + SPACE_BETWEEN_ELEMENT + `(?:\\s${ANY_OPENING_TAG}.*\\s*)*?` + START_OF_BRACKET + TYPE_NAME + ATTRIBUTE_SEPARATOR;
   },
 
   Combinator(node) {

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -56,7 +56,24 @@ export const visitor: Visitor = {
   ClassSelector(node, list) {
     if (node.data.type === 'ClassSelector') {
       // if (node.prev && node.prev.data.type === 'ClassSelector') {
-      // }
+
+      let t = [];
+      t.push(node);
+
+      if (node.next()) {
+        let next = node.next();
+        console.log('next: ', next);
+
+        // while (next) {
+        //   // if (next.data.type === 'ClassSelector') {
+        //   //   t.push(next);
+        //   // }
+        //   console.log('next: ', next);
+        //   next = next.next();
+        // }
+      }
+
+      console.log(t);
 
       return attributeRegexp(CLASS_ATTRIBUTE, node.data.name);
     }

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -93,8 +93,6 @@ const findAfter = (node: s2rNode<csstree.CssNode>, type: targetNode['type']) => 
 export const visitor: Visitor = {
   ClassSelector(node, list) {
     if (node.data.type === 'ClassSelector') {
-      // if (node.prev && node.prev.data.type === 'ClassSelector') {
-
       if (findBefore(node, 'ClassSelector').length > 0) {
         return '';
       }
@@ -102,7 +100,6 @@ export const visitor: Visitor = {
       const afters = findAfter(node, 'ClassSelector');
 
       if (afters.length > 0) {
-        // console.log(afters);
         return attributeRegexp(CLASS_ATTRIBUTE, [node.data.name, ...afters.map((node) => node.data.name)]);
       }
 

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -127,6 +127,21 @@ export const visitor: Visitor = {
     if (node.data.type !== 'TypeSelector') {
       return '';
     }
+
+    if (node.prev()) {
+      // Ignore Sibling, Descendant
+      if (node.prev()!.data.type === 'Combinator' || node.prev()!.data.type === 'WhiteSpace') {
+        return '';
+      }
+
+      // TypeSelector don't have these selectors
+      if (node.prev()!.data.type === 'TypeSelector' || node.prev()!.data.type === 'PseudoElementSelector' || node.prev()!.data.type === 'AttributeSelector' || node.prev()!.data.type === 'IdSelector' || node.prev()!.data.type === 'ClassSelector') {
+        return '';
+      }
+
+      // TODO: For multiple selectors implements
+    }
+
     return openingTagRegexp(node.data.name);
   },
 

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -80,7 +80,7 @@ const findAfter = (node: s2rNode<csstree.CssNode>, type: targetNode['type']) => 
 
   while (next) {
     const cursor = next;
-    if (cursor.data.type === type && cursor.prev().data.type !== 'WhiteSpace' && cursor.prev().data.type !== 'Combinator') {
+    if (cursor.data.type === type && cursor.prev()!.data.type !== 'WhiteSpace' && cursor.prev()!.data.type !== 'Combinator') {
       result.push(cursor);
     }
 
@@ -103,7 +103,7 @@ export const visitor: Visitor = {
     const afters = findAfter(node, 'ClassSelector');
 
     if (afters.length > 0) {
-      return attributeRegexp(CLASS_ATTRIBUTE, [node.data.name, ...afters.map((node) => node.data.name)]);
+      return attributeRegexp(CLASS_ATTRIBUTE, [node.data.name, ...afters.map((node) => (node.data as csstree.ClassSelector).name)]);
     }
 
     return attributeRegexp(CLASS_ATTRIBUTE, node.data.name);

--- a/src/lib/visitor.ts
+++ b/src/lib/visitor.ts
@@ -50,8 +50,12 @@ const attributeRegexp = <T extends string>(attribute: string, value: T | T[] | n
   return `${attribute}=${QUOTE}${valueRegexp(value)}${QUOTE}`;
 };
 
-const openingTagRegexp = (type: string, attribute?: string) => {
-  return START_OF_BRACKET + `(${type})` + '\\s*.*?' + END_OF_BRACKET;
+const openingTagRegexpNoClosing = (type: string) => {
+  return START_OF_BRACKET + `(${type})` + '\\s*.*?';
+};
+
+const openingTagRegexp = (type: string) => {
+  return openingTagRegexpNoClosing(type) + END_OF_BRACKET;
 };
 
 const closingTagRegexp = (type: string) => {
@@ -128,18 +132,27 @@ export const visitor: Visitor = {
       return '';
     }
 
-    if (node.prev()) {
-      // Ignore Sibling, Descendant
-      if (node.prev()!.data.type === 'Combinator' || node.prev()!.data.type === 'WhiteSpace') {
-        return '';
+    // if (node.prev()) {
+    //   return '';
+    // Ignore Sibling, Descendant
+    // if (node.prev()!.data.type === 'Combinator' || node.prev()!.data.type === 'WhiteSpace') {
+    //   return '';
+    // }
+    // Previous TypeSelector, don't have these selectors
+    // if (node.prev()!.data.type === 'TypeSelector' || node.prev()!.data.type === 'PseudoElementSelector' || node.prev()!.data.type === 'AttributeSelector' || node.prev()!.data.type === 'IdSelector' || node.prev()!.data.type === 'ClassSelector') {
+    //   return '';
+    // }
+    // }
+
+    if (node.next()) {
+      if (node.next()!.data.type === 'TypeSelector') {
+        throw new Error(`TypeSelector can't be in the next of name type`);
+      }
+      if (node.next()!.data.type === 'Combinator' || node.next()!.data.type === 'WhiteSpace') {
+        throw new Error(`TypeSelector doesn't support "Cominator" and "WhiteSpace"`);
       }
 
-      // TypeSelector don't have these selectors
-      if (node.prev()!.data.type === 'TypeSelector' || node.prev()!.data.type === 'PseudoElementSelector' || node.prev()!.data.type === 'AttributeSelector' || node.prev()!.data.type === 'IdSelector' || node.prev()!.data.type === 'ClassSelector') {
-        return '';
-      }
-
-      // TODO: For multiple selectors implements
+      return openingTagRegexpNoClosing(node.data.name);
     }
 
     return openingTagRegexp(node.data.name);

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -85,7 +85,7 @@ describe('generateRegexString()', () => {
     });
   });
 
-  describe('Multipe selector', () => {
+  describe('Multiple selector', () => {
     it('To match generated regexp in HTML', () => {
       expect(new RegExp(transformToRegexp(selector('.button.button--primary'))).test(`<button class="button button--primary"></button>`)).toBeTruthy();
     });

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -88,6 +88,7 @@ describe('generateRegexString()', () => {
   describe('Multiple selector', () => {
     it('To match generated regexp in HTML', () => {
       expect(new RegExp(transformToRegexp(selector('.button.button--primary'))).test(`<button class="button button--primary"></button>`)).toBeTruthy();
+      expect(new RegExp(transformToRegexp(selector('.button.button--primary.button--small'))).test(`<button class="button button--primary button--small"></button>`)).toBeTruthy();
     });
 
     it('To be false', () => {

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -89,6 +89,10 @@ describe('generateRegexString()', () => {
     it('To match generated regexp in HTML', () => {
       expect(new RegExp(transformToRegexp(selector('.button.button--primary'))).test(`<button class="button button--primary"></button>`)).toBeTruthy();
     });
+
+    it('To be false', () => {
+      expect(new RegExp(transformToRegexp(selector('.button .button--primary'))).test(`<button class="button button--primary"></button>`)).toBeFalsy();
+    });
   });
 
   describe('Unsupported selector', () => {

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -86,13 +86,28 @@ describe('generateRegexString()', () => {
   });
 
   describe('Multiple selector', () => {
-    it('To match generated regexp in HTML', () => {
-      expect(new RegExp(transformToRegexp(selector('.button.button--primary'))).test(`<button class="button button--primary"></button>`)).toBeTruthy();
-      expect(new RegExp(transformToRegexp(selector('.button.button--primary.button--small'))).test(`<button class="button button--primary button--small"></button>`)).toBeTruthy();
+    describe('ClassSelectors', () => {
+      it('To match generated regexp in HTML', () => {
+        expect(new RegExp(transformToRegexp(selector('.button.button--primary'))).test(`<button class="button button--primary"></button>`)).toBeTruthy();
+        expect(new RegExp(transformToRegexp(selector('.button.button--primary.button--small'))).test(`<button class="button button--primary button--small"></button>`)).toBeTruthy();
+      });
+
+      it('To be false', () => {
+        expect(new RegExp(transformToRegexp(selector('.button .button--primary'))).test(`<button class="button button--primary"></button>`)).toBeFalsy();
+      });
     });
 
-    it('To be false', () => {
-      expect(new RegExp(transformToRegexp(selector('.button .button--primary'))).test(`<button class="button button--primary"></button>`)).toBeFalsy();
+    describe('TypeSelector with any selectors', () => {
+      it('To match generated regexp in HTML', () => {
+        console.log(transformToRegexp(selector('div.panel')));
+        expect(new RegExp(transformToRegexp(selector('div.panel'))).test(`<div class="panel"></div>`)).toBeTruthy();
+
+        expect(new RegExp(transformToRegexp(selector('div.panel.panel--wide'))).test(`<div class="panel panel--wide"></div>`)).toBeTruthy();
+      });
+
+      it('To be false', () => {
+        expect(new RegExp(transformToRegexp(selector('div.panel'))).test(`<section class="panel"></section>`)).toBeFalsy();
+      });
     });
   });
 

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -85,10 +85,11 @@ describe('generateRegexString()', () => {
     });
   });
 
-  // describe('Selector list', () => {
-  //   it('To match generated regexp in HTML', () => {
-  //   });
-  // }
+  describe('Multipe selector', () => {
+    it('To match generated regexp in HTML', () => {
+      expect(new RegExp(transformToRegexp(selector('.button.button--primary'))).test(`<button class="button button--primary"></button>`)).toBeTruthy();
+    });
+  });
 
   describe('Unsupported selector', () => {
     it('with ">", "+" and "~" Combinator throw Error', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,3 +7,9 @@ export interface CssSearchSelector {
 export type CSSSelectorString = string;
 
 export type IdOrClassSelector = csstree.ClassSelector | csstree.IdSelector;
+
+export type s2rNode<N extends csstree.CssNode, Prev extends csstree.CssNode> = {
+  type: N['type'];
+  data: N;
+  prev: Prev | null;
+};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,8 +8,10 @@ export type CSSSelectorString = string;
 
 export type IdOrClassSelector = csstree.ClassSelector | csstree.IdSelector;
 
+export type targetNode = csstree.ClassSelector | csstree.IdSelector | csstree.TypeSelector | csstree.AttributeSelector | csstree.WhiteSpace | csstree.Combinator | csstree.PseudoElementSelector | csstree.SelectorList;
+
 export type s2rNode<N extends csstree.CssNode> = {
   data: N;
-  prev: s2rNode | null;
-  prev: s2rNode | null;
+  next: () => s2rNode | null;
+  prev: () => s2rNode | null;
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,8 +8,8 @@ export type CSSSelectorString = string;
 
 export type IdOrClassSelector = csstree.ClassSelector | csstree.IdSelector;
 
-export type s2rNode<N extends csstree.CssNode, Prev extends csstree.CssNode> = {
+export type s2rNode<N extends csstree.CssNode> = {
   type: N['type'];
   data: N;
-  prev: Prev | null;
+  prev: s2rNode | null;
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,6 +12,6 @@ export type targetNode = csstree.ClassSelector | csstree.IdSelector | csstree.Ty
 
 export type s2rNode<N extends csstree.CssNode> = {
   data: N;
-  next: () => s2rNode | null;
-  prev: () => s2rNode | null;
+  next: () => s2rNode<N> | null;
+  prev: () => s2rNode<N> | null;
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,7 @@ export type CSSSelectorString = string;
 export type IdOrClassSelector = csstree.ClassSelector | csstree.IdSelector;
 
 export type s2rNode<N extends csstree.CssNode> = {
-  type: N['type'];
   data: N;
+  prev: s2rNode | null;
   prev: s2rNode | null;
 };


### PR DESCRIPTION
Support multiple selector with className and type selector.

For example, I intended this case.

```sh
s2r '.button.button--primary'
s2r 'div.button--primary'
```