### PR TITLE
Fixed: Invalid result when s2r receives selector containing quotes.

### DIFF
--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -49,35 +49,34 @@ export const visitor: Visitor = {
       return '';
     }
 
-    let result: string;
+    if (node.data.matcher) {
+      let result: string;
 
-    switch (node.data.matcher) {
-      case null:
-        result = attributeRegexp(node.data.name.name);
-        break;
+      switch (node.data.matcher) {
+        case '=':
+          if (node.data.value) {
+            const value = node.data.value.type === 'Identifier' ? node.data.value.name : node.data.value.value;
+            result = attributeRegexp(node.data.name.name, value.replace(/(:?^['"]|['"]$)/g, ''), node.data.matcher);
+            break;
+          }
 
-      case '=':
-        if (node.data.value) {
-          const value = node.data.value.type === 'Identifier' ? node.data.value.name : node.data.value.value;
-          result = attributeRegexp(node.data.name.name, value.replace(/(:?^['"]|['"]$)/g, ''), node.data.matcher);
+          result = attributeRegexp(node.data.name.name);
           break;
-        }
-        result = attributeRegexp(node.data.name.name);
-        break;
+        case '~=':
+        case '$=':
+        case '^=':
+        case '*=':
+          result = attributeRegexp(node.data.name.name, (node.data.value as csstree.Identifier).name, node.data.matcher);
+          break;
+        default:
+          result = attributeRegexp(node.data.name.name, (node.data.value as csstree.Identifier).name);
+          break;
+      }
 
-      case '~=':
-      case '$=':
-      case '^=':
-      case '*=':
-        result = attributeRegexp(node.data.name.name, (node.data.value as csstree.Identifier).name, node.data.matcher);
-        break;
-
-      default:
-        result = attributeRegexp(node.data.name.name, (node.data.value as csstree.Identifier).name);
-        break;
+      return result;
+    } else {
+      return attributeRegexp(node.data.name.name);
     }
-
-    return result;
   },
 
   TypeSelector(node) {

--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -66,7 +66,7 @@ export const visitor: Visitor = {
         case '$=':
         case '^=':
         case '*=':
-          let value;
+          let value: null | string = null;
           if (node.data.value) {
             value = node.data.value.type === 'Identifier' ? node.data.value.name : node.data.value.value.replace(/[\"\']/g, '');
           }

--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -66,7 +66,12 @@ export const visitor: Visitor = {
         case '$=':
         case '^=':
         case '*=':
-          result = attributeRegexp(node.data.name.name, (node.data.value as csstree.Identifier).name, node.data.matcher);
+          let value;
+          if (node.data.value) {
+            value = node.data.value.type === 'Identifier' ? node.data.value.name : node.data.value.value.replace(/[\"\']/g, '');
+          }
+
+          result = attributeRegexp(node.data.name.name, value, node.data.matcher);
           break;
         default:
           result = attributeRegexp(node.data.name.name, (node.data.value as csstree.Identifier).name);

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -106,6 +106,19 @@ describe('generateRegexString()', () => {
       it('Should NOT match', () => {
         expect(testCase.test(`<div class="super-button"></div>`)).toBeFalsy();
       });
+
+      describe('when selector has double quotes', () => {
+        const testCase = new RegExp(transformToRegexp(selector('[class^="button-"]')));
+
+        it('Should match', () => {
+          expect(testCase.test(`<div class="button-small"></div>`)).toBeTruthy();
+        });
+
+        it('Should NOT match', () => {
+          expect(testCase.test(`<div class="super-button"></div>`)).toBeFalsy();
+          expect(testCase.test(`<div class="button"></div>`)).toBeFalsy();
+        });
+      });
     });
 
     describe('Matcher "$="', () => {

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -108,15 +108,21 @@ describe('generateRegexString()', () => {
       });
 
       describe('when selector has double quotes', () => {
-        const testCase = new RegExp(transformToRegexp(selector('[class^="button-"]')));
+        const selectorStr = transformToRegexp(selector('[class^=button-]'));
+        const selectorStrWithQuote = transformToRegexp(selector('[class^="button-"]'));
+        const testCaseWithQuote = new RegExp(selectorStrWithQuote);
+
+        it('Should be equal', () => {
+          expect(selectorStrWithQuote).toEqual(selectorStr);
+        });
 
         it('Should match', () => {
-          expect(testCase.test(`<div class="button-small"></div>`)).toBeTruthy();
+          expect(testCaseWithQuote.test(`<div class="button-small"></div>`)).toBeTruthy();
         });
 
         it('Should NOT match', () => {
-          expect(testCase.test(`<div class="super-button"></div>`)).toBeFalsy();
-          expect(testCase.test(`<div class="button"></div>`)).toBeFalsy();
+          expect(testCaseWithQuote.test(`<div class="super-button"></div>`)).toBeFalsy();
+          expect(testCaseWithQuote.test(`<div class="button"></div>`)).toBeFalsy();
         });
       });
     });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,7 @@
+import { attributeRegexp } from '../src/lib/visitor/utils';
+
+describe('attributeRegexp', () => {
+  it('One arg', () => {
+    expect(attributeRegexp('class')).toEqual('class');
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,7 +1,7 @@
 import { attributeRegexp } from '../src/lib/visitor/utils';
 
 describe('attributeRegexp', () => {
-  it('One arg', () => {
+  it('One argument', () => {
     expect(attributeRegexp('class')).toEqual('class');
   });
 });


### PR DESCRIPTION
https://github.com/m-yoshiro/Selector2Regexp/issues/13

```sh
s2r '[class^="icon-"]'
# => return class only :(
```