### PR TITLE
Replace csstree.parser's context: Selector -> SelectorList

### DIFF
--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -4,7 +4,7 @@ import { CSSSelectorString } from '../../types';
 export const parse = (selectorString: CSSSelectorString) => {
   try {
     return csstree.parse(selectorString.trim(), {
-      context: 'selector',
+      context: 'selectorList',
       onParseError: (error) => {
         console.log(error.message);
       },

--- a/src/lib/transformToRegexp.ts
+++ b/src/lib/transformToRegexp.ts
@@ -2,10 +2,11 @@ import csstree from 'css-tree';
 import { visitor } from './visitor/visitor';
 import { s2rNode, targetNode } from '../../types';
 
-export function transformToRegexp(selector: csstree.Selector) {
-  if (selector.type !== 'Selector') {
-    throw new Error(`Bad node type ${selector.type} for 'generateRegexString'.`);
-  }
+const isSelectorList = (selector: csstree.SelectorList | csstree.Selector) => selector.type === 'SelectorList' && selector.children.getSize() > 1;
+
+export function transformToRegexp(selector: csstree.SelectorList | csstree.Selector) {
+  // If selector is 'SelectorList' with more than two items, selector is identified as 'SelectorList'.
+  selector = isSelectorList(selector) ? selector : (selector.children.first() as csstree.Selector);
 
   const list: targetNode[] = [];
 

--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -119,6 +119,6 @@ export const visitor: Visitor = {
   },
 
   SelectorList() {
-    throw new Error('SelectorList, like a ".button-a, .button-b", is not supported.');
+    throw new Error('SelectorList, like a ".example-a, .example-b", is not supported.');
   },
 };

--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -119,6 +119,6 @@ export const visitor: Visitor = {
   },
 
   SelectorList() {
-    throw new Error('SelectorList, like a "a.button", is not supported.');
+    throw new Error('SelectorList, like a ".button-a, .button-b", is not supported.');
   },
 };

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -3,14 +3,18 @@ import csstree from 'css-tree';
 
 describe('convertToNodes', () => {
   it('with class selector', () => {
-    expect(parse('.example')).toStrictEqual(csstree.parse('.example', { context: 'selector' }));
+    expect(parse('.example')).toStrictEqual(csstree.parse('.example', { context: 'selectorList' }));
   });
 
   it('with ID selector', () => {
-    expect(parse('#example')).toStrictEqual(csstree.parse('#example', { context: 'selector' }));
+    expect(parse('#example')).toStrictEqual(csstree.parse('#example', { context: 'selectorList' }));
   });
 
   it('with multiple selector', () => {
-    expect(parse('.example .child')).toStrictEqual(csstree.parse('.example .child', { context: 'selector' }));
+    expect(parse('.example .child')).toStrictEqual(csstree.parse('.example .child', { context: 'selectorList' }));
+  });
+
+  it('with selector list', () => {
+    expect(parse('.example-a, .example-b')).toStrictEqual(csstree.parse('.example-a, .example-b', { context: 'selectorList' }));
   });
 });

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -3,7 +3,7 @@ import csstree from 'css-tree';
 
 const selector = (str: string) =>
   csstree.parse(str, {
-    context: 'selector',
+    context: 'selectorList',
   }) as csstree.Selector;
 
 describe('generateRegexString()', () => {

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -232,4 +232,10 @@ describe('generateRegexString()', () => {
       expect(() => transformToRegexp(selector('.example::after'))).toThrowError('Pseudo-elements "before" or "after" is not supported.');
     });
   });
+
+  describe('Selector List', () => {
+    it('Throw Error', () => {
+      expect(() => transformToRegexp(selector('.example-a, .example-b'))).toThrowError('SelectorList, like a ".example-a, .example-b", is not supported.');
+    });
+  });
 });


### PR DESCRIPTION
Replace `csstree.parser's` context: Selector -> SelectorList.
This change is preparation for implementing SelectorList soon.

This change is not effect any s2r's features.