### PR TITLE
Bugfix: Inaccurate results with descendant combinator 

### DIFF
--- a/src/lib/transformToRegexp.ts
+++ b/src/lib/transformToRegexp.ts
@@ -1,6 +1,6 @@
 import csstree from 'css-tree';
 import { visitor } from './visitor/visitor';
-import { s2rNode, targetNode } from '../../types';
+import { s2rListItem, targetNode } from '../../types';
 
 const isSelectorList = (selector: csstree.SelectorList | csstree.Selector) => selector.type === 'SelectorList' && selector.children.getSize() > 1;
 
@@ -11,7 +11,7 @@ export function transformToRegexp(selector: csstree.SelectorList | csstree.Selec
   const list: targetNode[] = [];
 
   const createS2rList = (list: targetNode[]) => {
-    const result: s2rNode<targetNode>[] = [];
+    const result: s2rListItem<targetNode>[] = [];
 
     list.forEach((node, i) => {
       result.push({

--- a/src/lib/transformToRegexp.ts
+++ b/src/lib/transformToRegexp.ts
@@ -1,6 +1,6 @@
 import csstree from 'css-tree';
 import { visitor } from './visitor/visitor';
-import { s2rList, targetNode } from '../../types';
+import { s2rList,  targetNode } from '../../types';
 
 const isSelectorList = (selector: csstree.SelectorList | csstree.Selector) => selector.type === 'SelectorList' && selector.children.getSize() > 1;
 
@@ -40,6 +40,6 @@ export function transformToRegexp(selector: csstree.SelectorList | csstree.Selec
   });
 
   return createS2rList(list)
-    .map((node) => visitor[node.data.type](node, list))
+    .map((listItem) => visitor[listItem.data.type](listItem, list))
     .join('');
 }

--- a/src/lib/transformToRegexp.ts
+++ b/src/lib/transformToRegexp.ts
@@ -1,28 +1,26 @@
 import csstree from 'css-tree';
 import { visitor } from './visitor/visitor';
-import { s2rListItem, targetNode } from '../../types';
+import { s2rList, targetNode } from '../../types';
 
 const isSelectorList = (selector: csstree.SelectorList | csstree.Selector) => selector.type === 'SelectorList' && selector.children.getSize() > 1;
+
+const createS2rList = (list: targetNode[]): s2rList<targetNode> => {
+  const result: s2rList<targetNode> = [];
+  list.forEach((node, i) => {
+    result.push({
+      data: node,
+      next: () => (result[i + 1] ? result[i + 1] : null),
+      prev: () => (result[i - 1] ? result[i - 1] : null),
+    });
+  });
+
+  return result;
+};
 
 export function transformToRegexp(selector: csstree.SelectorList | csstree.Selector) {
   // If selector is 'SelectorList' with more than two items, selector is identified as 'SelectorList'.
   selector = isSelectorList(selector) ? selector : (selector.children.first() as csstree.Selector);
-
   const list: targetNode[] = [];
-
-  const createS2rList = (list: targetNode[]) => {
-    const result: s2rListItem<targetNode>[] = [];
-
-    list.forEach((node, i) => {
-      result.push({
-        data: node,
-        next: () => (result[i + 1] ? result[i + 1] : null),
-        prev: () => (result[i - 1] ? result[i - 1] : null),
-      });
-    });
-
-    return result;
-  };
 
   csstree.walk(selector, (node) => {
     switch (node.type) {

--- a/src/lib/visitor/utils.ts
+++ b/src/lib/visitor/utils.ts
@@ -75,7 +75,7 @@ export const isPrevClassSelector = (node: s2rListItem<csstree.CssNode>) => {
   return prev && prev.data.type === 'ClassSelector';
 };
 
-export const findAfter = (node: s2rListItem<csstree.CssNode>, type: targetNode['type']) => {
+export const lookupForward = (node: s2rListItem<csstree.CssNode>, type: targetNode['type']) => {
   const result = [];
 
   let next = node.next();

--- a/src/lib/visitor/utils.ts
+++ b/src/lib/visitor/utils.ts
@@ -70,9 +70,9 @@ export const closingTagRegexp = (type: string) => {
   return START_OF_BRACKET + '/' + type + END_OF_BRACKET;
 };
 
-export const isPrevClassSelector = (node: s2rListItem<csstree.CssNode>, type: targetNode['type']) => {
+export const isPrevClassSelector = (node: s2rListItem<csstree.CssNode>) => {
   const prev = node.prev();
-  return prev && prev.data.type === type;
+  return prev && prev.data.type === 'ClassSelector';
 };
 
 export const findAfter = (node: s2rListItem<csstree.CssNode>, type: targetNode['type']) => {

--- a/src/lib/visitor/utils.ts
+++ b/src/lib/visitor/utils.ts
@@ -1,5 +1,5 @@
 import csstree from 'css-tree';
-import { s2rNode, targetNode } from '../../../types';
+import { s2rListItem, targetNode } from '../../../types';
 
 import { START_OF_BRACKET, END_OF_BRACKET, CLASS_ATTRIBUTE, ANY_VALUE, ID_ATTRIBUTE, SPACE_BETWEEN_ELEMENT, QUOTE, BEFORE_ATTRIBUTE, AFTER_ATTRIBUTE } from './definitions';
 
@@ -70,7 +70,7 @@ export const closingTagRegexp = (type: string) => {
   return START_OF_BRACKET + '/' + type + END_OF_BRACKET;
 };
 
-export const findBefore = (node: s2rNode<csstree.CssNode>, type: targetNode['type']) => {
+export const findBefore = (node: s2rListItem<csstree.CssNode>, type: targetNode['type']) => {
   const result = [];
 
   let prev = node.prev();
@@ -85,7 +85,7 @@ export const findBefore = (node: s2rNode<csstree.CssNode>, type: targetNode['typ
   return result;
 };
 
-export const findAfter = (node: s2rNode<csstree.CssNode>, type: targetNode['type']) => {
+export const findAfter = (node: s2rListItem<csstree.CssNode>, type: targetNode['type']) => {
   const result = [];
 
   let next = node.next();

--- a/src/lib/visitor/utils.ts
+++ b/src/lib/visitor/utils.ts
@@ -70,19 +70,9 @@ export const closingTagRegexp = (type: string) => {
   return START_OF_BRACKET + '/' + type + END_OF_BRACKET;
 };
 
-export const findBefore = (node: s2rListItem<csstree.CssNode>, type: targetNode['type']) => {
-  const result = [];
-
-  let prev = node.prev();
-
-  while (prev) {
-    if (prev.data.type === type) {
-      result.push(prev);
-    }
-    prev = prev.prev();
-  }
-
-  return result;
+export const isPrevClassSelector = (node: s2rListItem<csstree.CssNode>, type: targetNode['type']) => {
+  const prev = node.prev();
+  return prev && prev.data.type === type;
 };
 
 export const findAfter = (node: s2rListItem<csstree.CssNode>, type: targetNode['type']) => {

--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -25,7 +25,7 @@ export const visitor: Visitor = {
     }
 
     // Check current selector is multiple selector or not.
-    if (isPrevClassSelector(listItem, 'ClassSelector')) {
+    if (isPrevClassSelector(listItem)) {
       return '';
     }
 

--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -8,110 +8,110 @@ type SelectorRegexpString = string;
 type NoSupport = Error | void;
 
 export type Visitor = {
-  ClassSelector: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
-  IdSelector: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
-  AttributeSelector: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
-  WhiteSpace: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
-  TypeSelector: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
-  Combinator: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
-  PseudoElementSelector: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
-  SelectorList: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
+  ClassSelector: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  IdSelector: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  AttributeSelector: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  WhiteSpace: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  TypeSelector: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  Combinator: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
+  PseudoElementSelector: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
+  SelectorList: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
 };
 
 export const visitor: Visitor = {
-  ClassSelector(node) {
-    if (node.data.type !== 'ClassSelector') {
+  ClassSelector(listItem) {
+    if (listItem.data.type !== 'ClassSelector') {
       return '';
     }
 
-    if (findBefore(node, 'ClassSelector').length > 0) {
+    if (findBefore(listItem, 'ClassSelector').length > 0) {
       return '';
     }
 
-    const afters = findAfter(node, 'ClassSelector');
+    const afters = findAfter(listItem, 'ClassSelector');
 
     if (afters.length > 0) {
-      return classRegexp([node.data.name, ...afters.map((node) => (node.data as csstree.ClassSelector).name)]);
+      return classRegexp([listItem.data.name, ...afters.map((node) => (node.data as csstree.ClassSelector).name)]);
     }
 
-    return classRegexp(node.data.name);
+    return classRegexp(listItem.data.name);
   },
 
-  IdSelector(node) {
-    if (node.data.type !== 'IdSelector') {
+  IdSelector(listItem) {
+    if (listItem.data.type !== 'IdSelector') {
       return '';
     }
-    return idRegexp(node.data.name);
+    return idRegexp(listItem.data.name);
   },
 
-  AttributeSelector(node) {
-    if (node.data.type !== 'AttributeSelector') {
+  AttributeSelector(listItem) {
+    if (listItem.data.type !== 'AttributeSelector') {
       return '';
     }
 
-    if (node.data.matcher) {
+    if (listItem.data.matcher) {
       let result: string;
 
-      switch (node.data.matcher) {
+      switch (listItem.data.matcher) {
         case '=':
-          if (node.data.value) {
-            const value = node.data.value.type === 'Identifier' ? node.data.value.name : node.data.value.value;
-            result = attributeRegexp(node.data.name.name, value.replace(/(:?^['"]|['"]$)/g, ''), node.data.matcher);
+          if (listItem.data.value) {
+            const value = listItem.data.value.type === 'Identifier' ? listItem.data.value.name : listItem.data.value.value;
+            result = attributeRegexp(listItem.data.name.name, value.replace(/(:?^['"]|['"]$)/g, ''), listItem.data.matcher);
             break;
           }
 
-          result = attributeRegexp(node.data.name.name);
+          result = attributeRegexp(listItem.data.name.name);
           break;
         case '~=':
         case '$=':
         case '^=':
         case '*=':
           let value: null | string = null;
-          if (node.data.value) {
-            value = node.data.value.type === 'Identifier' ? node.data.value.name : node.data.value.value.replace(/[\"\']/g, '');
+          if (listItem.data.value) {
+            value = listItem.data.value.type === 'Identifier' ? listItem.data.value.name : listItem.data.value.value.replace(/[\"\']/g, '');
           }
 
-          result = attributeRegexp(node.data.name.name, value, node.data.matcher);
+          result = attributeRegexp(listItem.data.name.name, value, listItem.data.matcher);
           break;
         default:
-          result = attributeRegexp(node.data.name.name, (node.data.value as csstree.Identifier).name);
+          result = attributeRegexp(listItem.data.name.name, (listItem.data.value as csstree.Identifier).name);
           break;
       }
 
       return result;
     } else {
-      return attributeRegexp(node.data.name.name);
+      return attributeRegexp(listItem.data.name.name);
     }
   },
 
-  TypeSelector(node) {
-    if (node.data.type !== 'TypeSelector') {
+  TypeSelector(listItem) {
+    if (listItem.data.type !== 'TypeSelector') {
       return '';
     }
 
-    if (node.next()) {
-      if (node.next()!.data.type === 'TypeSelector') {
+    if (listItem.next()) {
+      if (listItem.next()!.data.type === 'TypeSelector') {
         throw new Error(`TypeSelector can't be in the next of name type`);
       }
-      if (node.next()!.data.type === 'Combinator' || node.next()!.data.type === 'WhiteSpace') {
+      if (listItem.next()!.data.type === 'Combinator' || listItem.next()!.data.type === 'WhiteSpace') {
         throw new Error(`TypeSelector doesn't support "Cominator" and "WhiteSpace"`);
       }
 
-      return openingTagRegexpNoClosing(node.data.name);
+      return openingTagRegexpNoClosing(listItem.data.name);
     }
 
-    return openingTagRegexp(node.data.name);
+    return openingTagRegexp(listItem.data.name);
   },
 
-  WhiteSpace(node) {
-    if (node.data.type !== 'WhiteSpace') {
+  WhiteSpace(listItem) {
+    if (listItem.data.type !== 'WhiteSpace') {
       return '';
     }
     return END_OF_BRACKET + SPACE_BETWEEN_ELEMENT + `(?:\\s${ANY_OPENING_TAG}.*\\s*)*?` + START_OF_BRACKET + TYPE_NAME + ATTRIBUTE_SEPARATOR;
   },
 
-  Combinator(node) {
-    throw new Error(`Combinator "${(node.data as csstree.Combinator).name}" is not supported.`);
+  Combinator(listItem) {
+    throw new Error(`Combinator "${(listItem.data as csstree.Combinator).name}" is not supported.`);
   },
 
   PseudoElementSelector() {

--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -24,7 +24,8 @@ export const visitor: Visitor = {
       return '';
     }
 
-    if (findBefore(listItem, 'ClassSelector').length > 0) {
+    // Check current selector is multiple selector or not.
+    if (isPrevClassSelector(listItem, 'ClassSelector')) {
       return '';
     }
 

--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -13,7 +13,7 @@ export type Visitor = {
   AttributeSelector: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
   WhiteSpace: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
   TypeSelector: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
-  Combinator: (listItem: s2rListItem<csstree.Combinator>, list?: targetNode[]) => SelectorRegexpString | NoSupport;
+  Combinator: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString | NoSupport;
   PseudoElementSelector: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
   SelectorList: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
 };
@@ -111,9 +111,14 @@ export const visitor: Visitor = {
   },
 
   Combinator(listItem) {
+    if (listItem.data.type !== 'Combinator') {
+      return '';
+    }
     switch (listItem.data.name) {
       case '>':
-        return 'TODO: return Child selector regexp';
+        return END_OF_BRACKET + SPACE_BETWEEN_ELEMENT + `(?:\\s${ANY_OPENING_TAG}.*\\s*)*?` + START_OF_BRACKET + TYPE_NAME + ATTRIBUTE_SEPARATOR;
+      case '+':
+      case '~':
       default:
         throw new Error(`Combinator "${(listItem.data as csstree.Combinator).name}" is not supported.`);
     }

--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -13,7 +13,7 @@ export type Visitor = {
   AttributeSelector: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
   WhiteSpace: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
   TypeSelector: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
-  Combinator: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
+  Combinator: (listItem: s2rListItem<csstree.Combinator>, list?: targetNode[]) => SelectorRegexpString | NoSupport;
   PseudoElementSelector: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
   SelectorList: (listItem: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
 };
@@ -111,7 +111,12 @@ export const visitor: Visitor = {
   },
 
   Combinator(listItem) {
-    throw new Error(`Combinator "${(listItem.data as csstree.Combinator).name}" is not supported.`);
+    switch (listItem.data.name) {
+      case '>':
+        return 'TODO: return Child selector regexp';
+      default:
+        throw new Error(`Combinator "${(listItem.data as csstree.Combinator).name}" is not supported.`);
+    }
   },
 
   PseudoElementSelector() {

--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -1,5 +1,5 @@
 import csstree from 'css-tree';
-import { s2rNode, targetNode } from '../../../types';
+import { s2rListItem, targetNode } from '../../../types';
 
 import { START_OF_BRACKET, END_OF_BRACKET, TYPE_NAME, ATTRIBUTE_SEPARATOR, SPACE_BETWEEN_ELEMENT, ANY_OPENING_TAG } from './definitions';
 import { attributeRegexp, classRegexp, idRegexp, openingTagRegexpNoClosing, openingTagRegexp, findBefore, findAfter } from './utils';
@@ -8,14 +8,14 @@ type SelectorRegexpString = string;
 type NoSupport = Error | void;
 
 export type Visitor = {
-  ClassSelector: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
-  IdSelector: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
-  AttributeSelector: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
-  WhiteSpace: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
-  TypeSelector: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
-  Combinator: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => NoSupport;
-  PseudoElementSelector: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => NoSupport;
-  SelectorList: (node: s2rNode<csstree.CssNode>, list?: targetNode[]) => NoSupport;
+  ClassSelector: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  IdSelector: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  AttributeSelector: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  WhiteSpace: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  TypeSelector: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => SelectorRegexpString;
+  Combinator: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
+  PseudoElementSelector: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
+  SelectorList: (node: s2rListItem<csstree.CssNode>, list?: targetNode[]) => NoSupport;
 };
 
 export const visitor: Visitor = {

--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -117,7 +117,6 @@ export const visitor: Visitor = {
     }
     switch (listItem.data.name) {
       case '>':
-        return END_OF_BRACKET + SPACE_BETWEEN_ELEMENT + '(?=<)';
       case '+':
       case '~':
       default:

--- a/src/lib/visitor/visitor.ts
+++ b/src/lib/visitor/visitor.ts
@@ -2,7 +2,7 @@ import csstree from 'css-tree';
 import { s2rListItem, targetNode } from '../../../types';
 
 import { START_OF_BRACKET, END_OF_BRACKET, TYPE_NAME, ATTRIBUTE_SEPARATOR, SPACE_BETWEEN_ELEMENT, ANY_OPENING_TAG } from './definitions';
-import { attributeRegexp, classRegexp, idRegexp, openingTagRegexpNoClosing, openingTagRegexp, findBefore, findAfter } from './utils';
+import { attributeRegexp, classRegexp, idRegexp, openingTagRegexpNoClosing, openingTagRegexp, isPrevClassSelector, lookupForward } from './utils';
 
 type SelectorRegexpString = string;
 type NoSupport = Error | void;
@@ -24,13 +24,13 @@ export const visitor: Visitor = {
       return '';
     }
 
-    // Check current selector is multiple selector or not.
+    // Skip when prev item is ClassSelector.
     if (isPrevClassSelector(listItem)) {
       return '';
     }
 
-    const afters = findAfter(listItem, 'ClassSelector');
-
+    // For multiple selector
+    const afters = lookupForward(listItem, 'ClassSelector');
     if (afters.length > 0) {
       return classRegexp([listItem.data.name, ...afters.map((node) => (node.data as csstree.ClassSelector).name)]);
     }
@@ -117,7 +117,7 @@ export const visitor: Visitor = {
     }
     switch (listItem.data.name) {
       case '>':
-        return END_OF_BRACKET + SPACE_BETWEEN_ELEMENT + `(?:\\s${ANY_OPENING_TAG}.*\\s*)*?` + START_OF_BRACKET + TYPE_NAME + ATTRIBUTE_SEPARATOR;
+        return END_OF_BRACKET + SPACE_BETWEEN_ELEMENT + '(?=<)';
       case '+':
       case '~':
       default:

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -240,20 +240,21 @@ describe('generateRegexString()', () => {
     });
   });
 
-  describe('Child combinator', () => {
-    it('Should match', () => {
-      expect(new RegExp(transformToRegexp(selector('.parent > .child'))).test(`<div class="parent"><div class="child"></div></div>`)).toBeTruthy();
-    });
+  // describe('Child combinator', () => {
+  //   it('Should match', () => {
+  //     expect(new RegExp(transformToRegexp(selector('.parent > .child'))).test(`<div class="parent"><div class="child"></div></div>`)).toBeTruthy();
+  //   });
 
-    it('Should NOT match', () => {
-      console.log(selector('.parent > .child').children.last());
-      console.log(transformToRegexp(selector('.parent > .child')));
-      expect(new RegExp(transformToRegexp(selector('.parent > .child'))).test(`<div class="parent"><div class="wrapper"><div class="child"></div></div></div>`)).toBeFalsy();
-    });
-  });
+  //   it('Should NOT match', () => {
+  //     console.log(selector('.parent > .child').children.last());
+  //     console.log(transformToRegexp(selector('.parent > .child')));
+  //     expect(new RegExp(transformToRegexp(selector('.parent > .child'))).test(`<div class="parent"><div class="wrapper"><div class="child"></div></div></div>`)).toBeFalsy();
+  //   });
+  // });
 
   describe('Unsupported selector', () => {
     it('Throw Error with ">", "+" and "~" Combinator', () => {
+      expect(() => transformToRegexp(selector('.parent > .child'))).toThrowError('Combinator ">" is not supported.');
       expect(() => transformToRegexp(selector('.example + .adjacentSibling'))).toThrowError('Combinator "+" is not supported.');
       expect(() => transformToRegexp(selector('.example ~ .sibling'))).toThrowError('Combinator "~" is not supported.');
     });

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -220,6 +220,12 @@ describe('generateRegexString()', () => {
     });
   });
 
+  describe('Child combinator', () => {
+    it('Should match', () => {
+      expect(new RegExp(transformToRegexp(selector('.parent > .child'))).test(`<div class="parent"><div class="child"></div></div>`)).toBeTruthy();
+    });
+  });
+
   describe('Unsupported selector', () => {
     it('Throw Error with ">", "+" and "~" Combinator', () => {
       expect(() => transformToRegexp(selector('.example > .child'))).toThrowError('Combinator ">" is not supported.');

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -166,6 +166,7 @@ describe('generateRegexString()', () => {
 
   describe('Whitespace combinator', () => {
     const testCase = new RegExp(transformToRegexp(selector('.example .child')));
+    console.log(testCase);
 
     it('Should match when HTML strings without any spaces or newline', () => {
       expect(testCase.test(`<div class="example"><div class="child"></div></div>`)).toBeTruthy();
@@ -204,7 +205,8 @@ describe('generateRegexString()', () => {
       });
 
       it('Should NOT match', () => {
-        expect(new RegExp(transformToRegexp(selector('.button .button--primary'))).test(`<button class="button button--primary"></button>`)).toBeFalsy();
+        expect(new RegExp(transformToRegexp(selector('.button.button--primary'))).test(`<button class="button"><span class="bad"></span></button>`)).toBeFalsy();
+        expect(new RegExp(transformToRegexp(selector('.button.button--primary'))).test(`<button class="button--primary"><span class="bad"></span></button>`)).toBeFalsy();
       });
     });
 
@@ -223,6 +225,12 @@ describe('generateRegexString()', () => {
   describe('Child combinator', () => {
     it('Should match', () => {
       expect(new RegExp(transformToRegexp(selector('.parent > .child'))).test(`<div class="parent"><div class="child"></div></div>`)).toBeTruthy();
+    });
+
+    it('Should NOT match', () => {
+      console.log(selector('.parent > .child').children.last());
+      console.log(transformToRegexp(selector('.parent > .child')));
+      expect(new RegExp(transformToRegexp(selector('.parent > .child'))).test(`<div class="parent"><div class="wrapper"><div class="child"></div></div></div>`)).toBeFalsy();
     });
   });
 

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -195,6 +195,24 @@ describe('generateRegexString()', () => {
         `)
       ).toBeTruthy();
     });
+
+    it('Should NOT match', () => {
+      expect(
+        testCase.test(`
+          <div class="example">
+            <div class="bad"></div>
+          </div>
+        `)
+      ).toBeFalsy();
+
+      expect(
+        testCase.test(`
+          <div class="example child">
+            <div class="bad"></div>
+          </div>
+        `)
+      ).toBeFalsy();
+    });
   });
 
   describe('Multiple selector', () => {

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -166,7 +166,6 @@ describe('generateRegexString()', () => {
 
   describe('Whitespace combinator', () => {
     const testCase = new RegExp(transformToRegexp(selector('.example .child')));
-    console.log(testCase);
 
     it('Should match when HTML strings without any spaces or newline', () => {
       expect(testCase.test(`<div class="example"><div class="child"></div></div>`)).toBeTruthy();
@@ -246,8 +245,6 @@ describe('generateRegexString()', () => {
   //   });
 
   //   it('Should NOT match', () => {
-  //     console.log(selector('.parent > .child').children.last());
-  //     console.log(transformToRegexp(selector('.parent > .child')));
   //     expect(new RegExp(transformToRegexp(selector('.parent > .child'))).test(`<div class="parent"><div class="wrapper"><div class="child"></div></div></div>`)).toBeFalsy();
   //   });
   // });

--- a/tests/transformToRegexp.test.ts
+++ b/tests/transformToRegexp.test.ts
@@ -228,7 +228,6 @@ describe('generateRegexString()', () => {
 
   describe('Unsupported selector', () => {
     it('Throw Error with ">", "+" and "~" Combinator', () => {
-      expect(() => transformToRegexp(selector('.example > .child'))).toThrowError('Combinator ">" is not supported.');
       expect(() => transformToRegexp(selector('.example + .adjacentSibling'))).toThrowError('Combinator "+" is not supported.');
       expect(() => transformToRegexp(selector('.example ~ .sibling'))).toThrowError('Combinator "~" is not supported.');
     });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,10 +8,18 @@ export type CSSSelectorString = string;
 
 export type IdOrClassSelector = csstree.ClassSelector | csstree.IdSelector;
 
-export type targetNode = csstree.ClassSelector | csstree.IdSelector | csstree.TypeSelector | csstree.AttributeSelector | csstree.WhiteSpace | csstree.Combinator | csstree.PseudoElementSelector | csstree.SelectorList;
+export type targetNode =
+  | csstree.ClassSelector
+  | csstree.IdSelector
+  | csstree.TypeSelector
+  | csstree.AttributeSelector
+  | csstree.WhiteSpace
+  | csstree.Combinator
+  | csstree.PseudoElementSelector
+  | csstree.SelectorList;
 
-export type s2rNode<N extends csstree.CssNode> = {
+export type s2rListItem<N extends csstree.CssNode> = {
   data: N;
-  next: () => s2rNode<N> | null;
-  prev: () => s2rNode<N> | null;
+  next: () => s2rListItem<N> | null;
+  prev: () => s2rListItem<N> | null;
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,3 +23,5 @@ export type s2rListItem<N extends csstree.CssNode> = {
   next: () => s2rListItem<N> | null;
   prev: () => s2rListItem<N> | null;
 };
+
+export type s2rList<N extends csstree.CssNode> = s2rListItem<N>[];


### PR DESCRIPTION
Fixed inaccurate results with descendant combinator.
In this case below, it must contain the word 'child'. But it dose not.

```sh
# input
s2r '.parent .child'
```
In addition, I reconsider some small implements.