### PR TITLE
Fix generated regex for multiple selector

### DIFF
--- a/src/lib/generate/classGenerate.ts
+++ b/src/lib/generate/classGenerate.ts
@@ -1,13 +1,5 @@
 import { ANY, ANY_VALUE, SPACE_BETWEEN_ELEMENT, QUOTE, BEFORE_ATTRIBUTE, AFTER_ATTRIBUTE, SPACE_BETWEEN_VALUE } from '../utils/definitions';
 
-const wrapQuate = (value: string) => {
-  return `${QUOTE}${value}${QUOTE}`;
-};
-
-const ignoreDuplication = (value: string) => {
-  return `(?<![^\\w]${value}\\s+${ANY})(?:${ANY})${value}(?!\\w).*(?![^\\w]${value}[^\\w])`;
-};
-
 export const attributeRegexpTemplate = (name: string, value?: string) => {
   if (!value) {
     return name;

--- a/src/lib/generate/classGenerate.ts
+++ b/src/lib/generate/classGenerate.ts
@@ -1,4 +1,4 @@
-import { ANY, ANY_VALUE, SPACE_BETWEEN_ELEMENT, QUOTE, BEFORE_ATTRIBUTE, AFTER_ATTRIBUTE, SPACE_BETWEEN_VALUE } from '../utils/definitions';
+import { ANY_VALUE, QUOTE, BEFORE_ATTRIBUTE, AFTER_ATTRIBUTE, SPACE_BETWEEN_VALUE } from '../utils/definitions';
 
 export const attributeRegexpTemplate = (name: string, value?: string) => {
   if (!value) {

--- a/src/lib/generate/classGenerate.ts
+++ b/src/lib/generate/classGenerate.ts
@@ -1,26 +1,41 @@
-import { ANY_VALUE, SPACE_BETWEEN_ELEMENT, QUOTE, BEFORE_ATTRIBUTE, AFTER_ATTRIBUTE, SPACE_BETWEEN_VALUE } from '../utils/definitions';
+import { ANY, ANY_VALUE, SPACE_BETWEEN_ELEMENT, QUOTE, BEFORE_ATTRIBUTE, AFTER_ATTRIBUTE, SPACE_BETWEEN_VALUE } from '../utils/definitions';
 
 const wrapQuate = (value: string) => {
   return `${QUOTE}${value}${QUOTE}`;
+};
+
+const ignoreDuplication = (value: string) => {
+  return `(?<![^\\w]${value}\\s+${ANY})(?:${ANY})${value}(?!\\w).*(?![^\\w]${value}[^\\w])`;
 };
 
 export const attributeRegexpTemplate = (name: string, value?: string) => {
   if (!value) {
     return name;
   }
-  return `${name}=${wrapQuate(value)}`;
+  return `${name}=${value}`;
 };
 
 export const classToRegexp = (classList: string[]) => {
-  const valueString = classList.join('|');
-  const n = classList.length;
+  const isMultiple = classList.length >= 2;
+  let valueString: string;
+
+  if (isMultiple) {
+    valueString = classList
+      .map((classItem) => {
+        return `(?=(.*[\\s'"]${classItem}[\\s'"]))`;
+      })
+      .join('');
+  } else {
+    valueString = classList[0];
+  }
+
   const attrName = 'class';
   let valueRegex: string;
 
-  if (n > 1) {
-    valueRegex = ANY_VALUE + '(' + SPACE_BETWEEN_ELEMENT + BEFORE_ATTRIBUTE + `(${valueString})` + AFTER_ATTRIBUTE + SPACE_BETWEEN_ELEMENT + ')' + `{${n}}` + ANY_VALUE;
+  if (isMultiple) {
+    valueRegex = `(?=${QUOTE})(${valueString}.*)(?=${QUOTE})`;
   } else {
-    valueRegex = ANY_VALUE + SPACE_BETWEEN_VALUE + BEFORE_ATTRIBUTE + `(${valueString})` + AFTER_ATTRIBUTE + SPACE_BETWEEN_VALUE + ANY_VALUE;
+    valueRegex = QUOTE + ANY_VALUE + SPACE_BETWEEN_VALUE + BEFORE_ATTRIBUTE + `(${valueString})` + AFTER_ATTRIBUTE + SPACE_BETWEEN_VALUE + ANY_VALUE + QUOTE;
   }
 
   return attributeRegexpTemplate(attrName, valueRegex);

--- a/src/lib/utils/definitions.ts
+++ b/src/lib/utils/definitions.ts
@@ -1,6 +1,6 @@
 export const START_OF_BRACKET = '<\\s*';
 export const END_OF_BRACKET = '\\s*>';
-export const ANY_TYPE_NAME = '\\w+';
+export const ANY_TYPE_NAME = '[a-zA-Z]+';
 export const CLASS_ATTRIBUTE = 'class';
 export const ANY_VALUE = '\\w*';
 export const ANY_ATTRIBUTE_NAME = '[\\w-]*';

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -15,6 +15,6 @@ const cliMock = async (args: string[]) => {
 
 describe('CLI', () => {
   it('.button', async () => {
-    await expect(cliMock(['.button'])).resolves.toBe('<\\s*(\\w+)\\s+.*(class=[\'"]\\w*\\s*(?<!\\w)(button)(?!\\w)\\s*\\w*[\'"]).*\\s*>' + '\n');
+    await expect(cliMock(['.button'])).resolves.toBe('<\\s*([a-zA-Z]+)\\s+.*(class=[\'"]\\w*\\s*(?<!\\w)(button)(?!\\w)\\s*\\w*[\'"]).*\\s*>' + '\n');
   });
 });

--- a/tests/generate-match.test.ts
+++ b/tests/generate-match.test.ts
@@ -233,6 +233,7 @@ describe('Matching', () => {
         const testCase = new RegExp(generate(selector));
 
         it('Should match', () => {
+          console.log(testCase.toString());
           expect(testCase.test(`<button class="button button--primary"></button>`)).toBeTruthy();
           expect(testCase.test(`<button id="main" class="button button--primary"></button>`)).toBeTruthy();
         });

--- a/tests/generate-match.test.ts
+++ b/tests/generate-match.test.ts
@@ -233,8 +233,9 @@ describe('Matching', () => {
         const testCase = new RegExp(generate(selector));
 
         it('Should match', () => {
-          console.log(testCase.toString());
           expect(testCase.test(`<button class="button button--primary"></button>`)).toBeTruthy();
+          expect(testCase.test(`<button class="button other button--primary"></button>`)).toBeTruthy();
+          expect(testCase.test(`<button class="button--primary other button"></button>`)).toBeTruthy();
           expect(testCase.test(`<button id="main" class="button button--primary"></button>`)).toBeTruthy();
         });
 


### PR DESCRIPTION
There were some problems with multiple selector.

1. It doesn't match if the target element has attribute values more than given selector
   * ex. `s2r .button.button--primary`  doesn't match  the following case
`<div class="button other button--primary">`
2. Unexpectedly, it matches duplicated class names.
   * ex. `s2r .button.button--primary` matches the following case
`<div class="button button">`