### PR TITLE
To enable to generate valid regex if reserved path strings

### DIFF
--- a/src/lib/convert/convertAst.ts
+++ b/src/lib/convert/convertAst.ts
@@ -35,15 +35,12 @@ export const convertToAst = (ast: CssNode) => {
         } else if (node.type === 'AttributeSelector') {
           attr.name = typeof node.name === 'string' ? node.name : node.name.name;
           attr.value = (() => {
-            let value = '';
+            // eslint-disable-next-line prettier/prettier
+            let value = 
+              node.value?.type === 'Identifier' ? node.value.name :
+              node.value?.type === 'String' ? node.value.value : null;
 
-            if (node.value?.type === 'Identifier') {
-              value = node.value.name;
-            } else if (node.value?.type === 'String') {
-              value = node.value.value;
-            }
-
-            value = escapeRegExp(value);
+            value = value && escapeRegExp(value);
 
             return value;
           })();

--- a/src/lib/convert/convertAst.ts
+++ b/src/lib/convert/convertAst.ts
@@ -7,10 +7,6 @@ import { Attribute } from '../../../types';
 export const convertToAst = (ast: CssNode) => {
   let current: Element;
   const result = new Selector();
-  const INNER_ATTR_NAME = {
-    ClassSelector: 'class',
-    IdSelector: 'id',
-  };
 
   walk(ast, (node, item) => {
     // Skip

--- a/src/lib/convert/convertAst.ts
+++ b/src/lib/convert/convertAst.ts
@@ -3,6 +3,7 @@ import { Element } from '../node/element';
 import { Combinator } from '../node/combinator';
 import { Selector } from '../node/selector';
 import { Attribute } from '../../../types';
+import { escapeRegExp } from '../utils';
 
 export const convertToAst = (ast: CssNode) => {
   let current: Element;
@@ -34,11 +35,17 @@ export const convertToAst = (ast: CssNode) => {
         } else if (node.type === 'AttributeSelector') {
           attr.name = typeof node.name === 'string' ? node.name : node.name.name;
           attr.value = (() => {
+            let value = '';
+
             if (node.value?.type === 'Identifier') {
-              return node.value.name;
+              value = node.value.name;
             } else if (node.value?.type === 'String') {
-              return node.value.value;
+              value = node.value.value;
             }
+
+            value = escapeRegExp(value);
+
+            return value;
           })();
           attr.matcher = node.matcher;
         }

--- a/src/lib/generate/attributeGenerate.ts
+++ b/src/lib/generate/attributeGenerate.ts
@@ -1,5 +1,5 @@
 import { Attribute } from '../../../types';
-import { QUOTE, QUOTE_OR_SPACE, ANY } from '../utils/definitions';
+import { QUOTE, QUOTE_OR_SPACE, ANY, ANY_VALUE_CHARACTER } from '../utils/definitions';
 import { attributeRegexpTemplate } from './attributeRegexTemplate';
 
 const prerequisite = (condition: string) => `(?=(${ANY}${QUOTE_OR_SPACE}${condition}${QUOTE_OR_SPACE}))`;
@@ -15,11 +15,11 @@ const convertValueWithMatcher = (attrValue: Attribute) => {
       // This matcher needs a strict condition
       result = `${QUOTE}${value}${QUOTE}`;
     } else if (matcher === '*=') {
-      result = `(?=${QUOTE})${prerequisite(`[\\w\\d_-\\s]*?${value}[\\w\\d_-\\s]*?`)}${ANY}(?=${QUOTE})`;
+      result = `(?=${QUOTE})${prerequisite(`[\\w\\d\\/\\.:_-\\s]*?${value}[\\w\\d\\/\\.:_-\\s]*?`)}${ANY}(?=${QUOTE})`;
     } else if (matcher === '^=') {
-      result = `(?=${QUOTE})${prerequisite(`${value}[\\w\\d_-]*?`)}${ANY}(?=${QUOTE})`;
+      result = `(?=${QUOTE})${prerequisite(`${value}${ANY_VALUE_CHARACTER}*?`)}${ANY}(?=${QUOTE})`;
     } else if (matcher === '$=') {
-      result = `(?=${QUOTE})${prerequisite(`[\\w\\d_-]*?${value}`)}${ANY}(?=${QUOTE})`;
+      result = `(?=${QUOTE})${prerequisite(`${ANY_VALUE_CHARACTER}*?${value}`)}${ANY}(?=${QUOTE})`;
     } else if (matcher === '~=') {
       result = `(?=${QUOTE})${prerequisite(value)}${ANY}(?=${QUOTE})`;
     } else {

--- a/src/lib/generate/elementGenerate.ts
+++ b/src/lib/generate/elementGenerate.ts
@@ -1,4 +1,4 @@
-import { START_OF_BRACKET, END_OF_BRACKET, ANY_TYPE_NAME, ATTRIBUTE_SEPARATOR, ANY } from '../utils/definitions';
+import { START_OF_BRACKET, END_OF_BRACKET, ANY_TYPE_NAME, ATTRIBUTE_SEPARATOR, ANY, ANY_IN_ELEMENT } from '../utils/definitions';
 
 const attributesCompile = (attrs: string[]) => {
   if (attrs.length >= 2) {
@@ -11,7 +11,7 @@ const attributesCompile = (attrs: string[]) => {
 export const elementTemplate = (value: { type?: string; attributes?: string[] }) => {
   const { type, attributes } = value;
   if (!attributes || attributes.length < 1) {
-    return START_OF_BRACKET + `(${value.type})` + '\\s*.*?' + END_OF_BRACKET;
+    return START_OF_BRACKET + `(${value.type})` + `\\s*${ANY_IN_ELEMENT}` + END_OF_BRACKET;
   }
 
   return START_OF_BRACKET + `(${type || ANY_TYPE_NAME})` + ATTRIBUTE_SEPARATOR + attributesCompile(attributes) + END_OF_BRACKET;

--- a/src/lib/utils/definitions.ts
+++ b/src/lib/utils/definitions.ts
@@ -16,3 +16,6 @@ export const AFTER_ATTRIBUTE = '(?!\\w)';
 export const ANY_OPENING_TAG = '<.*>';
 export const ANY_CLOSING_TAG = '</.*>';
 export const ANY = '.*';
+export const ANY_ELEMENT_CHARACTER = '[^<>]';
+export const ANY_IN_ELEMENT = `${ANY_ELEMENT_CHARACTER}*`;
+export const ANY_VALUE_CHARACTER = '[\\w\\d\\/\\.:_-]';

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -4,4 +4,4 @@ export const uniqueArray = <U = any>(arr: U[]): U[] => [...new Set(arr.map((item
  * Escape any special characters to use it for regexp
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
  */
-export const escapeRegExp = (string: string) => string.replace(/[.*+?^=!:${}()|[\]\/\\]/g, '\\$&'); // $&はマッチした部分文字列全体を意味します
+export const escapeRegExp = (string: string) => string.replace(/[.*+?^=!:${}()|[\]\/\\]/g, '\\$&');

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,1 +1,7 @@
 export const uniqueArray = <U = any>(arr: U[]): U[] => [...new Set(arr.map((item) => JSON.stringify(item)))].map((item) => JSON.parse(item));
+
+/**
+ * Escape any special characters to use it for regexp
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+ */
+export const escapeRegExp = (string: string) => string.replace(/[.*+?^=!:${}()|[\]\/\\]/g, '\\$&'); // $&はマッチした部分文字列全体を意味します

--- a/tests/generate-match.test.ts
+++ b/tests/generate-match.test.ts
@@ -133,8 +133,18 @@ describe('Matching', () => {
         },
       });
 
+      const testCaseWithPath = makeTest({
+        attr: {
+          name: 'href',
+          value: 'https://schdhdkej/',
+          matcher: '^=',
+        },
+      });
+
       it('Should match', () => {
         expect(testCase.test(`<div class="button-small"></div>`)).toBeTruthy();
+        expect(testCase.test(`<a href="https://schdhdkej/"></a>`)).toBeTruthy();
+        expect(testCaseWithPath.test(`<a href="https://schdhdkej/index.html"></a>`)).toBeTruthy();
       });
 
       it('Should NOT match', () => {
@@ -181,11 +191,20 @@ describe('Matching', () => {
         },
       });
 
+      const testCaseWithPath = makeTest({
+        attr: {
+          name: 'href',
+          value: '/index.html',
+          matcher: '$=',
+        },
+      });
+
       it('Should match', () => {
         expect(testCase.test(`<div class="super-box"></div>`)).toBeTruthy();
         expect(testCase.test(`<div class="box"></div>`)).toBeTruthy();
         expect(testCase.test(`<div class="presentbox other"></div>`)).toBeTruthy();
         expect(testCase.test(`<div class="superlongclassnamebox"></div>`)).toBeTruthy();
+        expect(testCaseWithPath.test(`<a href="https://kkdddwe/index.html"></a>`)).toBeTruthy();
       });
       it('Should NOT match', () => {
         expect(testCase.test(`<div class="box-super"></div>`)).toBeFalsy();

--- a/tests/generate-match.test.ts
+++ b/tests/generate-match.test.ts
@@ -143,7 +143,7 @@ describe('Matching', () => {
 
       it('Should match', () => {
         expect(testCase.test(`<div class="button-small"></div>`)).toBeTruthy();
-        expect(testCase.test(`<a href="https://schdhdkej/"></a>`)).toBeTruthy();
+        expect(testCaseWithPath.test(`<a href="https://schdhdkej/"></a>`)).toBeTruthy();
         expect(testCaseWithPath.test(`<a href="https://schdhdkej/index.html"></a>`)).toBeTruthy();
       });
 


### PR DESCRIPTION
To enable to generate valid regex if reserved path strings.

```sh
#example
s2r '[href^=https://]'
```

And, I fixed a small bug that it might be match unexpected closing tag.