### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ After saving clipboard, paste it on a search input of your editor.
 # Type Selector
   s2r 'div'
 
-# Classs Selector
+# Class Selector
   s2r '.single'
 
 # Id Selector


### PR DESCRIPTION
## Summary
- fix heading typo from `Classs Selector` to `Class Selector`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68427a67d1ec8320b1fa72345b6661c3