### PR TITLE
Update workflow Node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14.x, 16.x, 18.x]
+        node: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v2
       with:
-        node-version: 14
+        node-version: 18
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - run: npm run test


### PR DESCRIPTION
## Summary
- use Node `18.x` and `20.x` in CI
- publish with Node 18
- release-please uses Node 18

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e87689288320987f908c97e7ff83